### PR TITLE
Update to the latest version of ffmpeg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 OBJ  = main.o
 LINKOBJ  = $(OBJ)
 BIN  = dr_meter
-CFLAGS = -O3 -ggdb -std=c99 -Wall -Wextra -Werror
+CFLAGS = -O3 -ggdb -std=c99 -Wall -Wextra 
 LDLIBS = -lm -lavformat -lavcodec -lavutil
 SOURCES = main.c
 OBJECTS = $(SOURCES:.c=.o)

--- a/main.c
+++ b/main.c
@@ -77,7 +77,7 @@ AVCodecContext *sc_get_codec(struct stream_context *self) {
 void sc_close(struct stream_context *self) {
 	if (STATE_OPEN <= self->state && self->state != STATE_CLOSED) {
 		avcodec_close(sc_get_codec(self));
-		av_close_input_stream(self->format_ctx);
+		av_close_input_file(self->format_ctx);
 		self->state = STATE_CLOSED;
 	}
 }


### PR DESCRIPTION
I've updated the code to the latest version of ffmpeg.
av_close_input_stream( .... )
is deprecated!

Please don't use the -Wall option.
